### PR TITLE
Improve production settings

### DIFF
--- a/feedback/settings_production.py
+++ b/feedback/settings_production.py
@@ -1,10 +1,13 @@
 from feedback.settings import *
-import dj_database_url
 import os
-DATABASES['default'] = dj_database_url.config()
+import django_heroku
+
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-ALLOWED_HOSTS = ['*']
 DEBUG = False
-STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+
+# Set up the app for Heroku
+# see: https://devcenter.heroku.com/articles/django-app-configuration#settings-py-changes
+
+django_heroku.settings(locals())

--- a/feedback/settings_production.py
+++ b/feedback/settings_production.py
@@ -1,13 +1,54 @@
-from feedback.settings import *
 import os
+import sys
+
 import django_heroku
+
+from feedback.settings import *
+
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 DEBUG = False
 
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
+
 # Set up the app for Heroku
 # see: https://devcenter.heroku.com/articles/django-app-configuration#settings-py-changes
 
 django_heroku.settings(locals())
+
+
+# Log to "sys.stdout" rather than the default stderr, so that Heroku logs pick
+# up error tracebacks
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': ('%(asctime)s [%(process)d] [%(levelname)s] ' +
+                        'pathname=%(pathname)s lineno=%(lineno)s ' +
+                        'funcname=%(funcName)s %(message)s'),
+            'datefmt': '%Y-%m-%d %H:%M:%S'
+        },
+        'simple': {
+            'format': '%(levelname)s %(message)s'
+        },
+    },
+    'handlers': {
+        'null': {
+            'level': 'DEBUG',
+            'class': 'logging.NullHandler',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+            'stream': sys.stdout,
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'WARNING',
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 gunicorn==19.9.0
 psycopg2==2.7.3.2
 waitress==1.4.3
+django-heroku==0.3.1


### PR DESCRIPTION
- Use `django_heroku` as suggested in [Heroku docs](https://devcenter.heroku.com/articles/django-app-configuration#settings-py-changes)
- Log to stdout rather than stderr, so tracebacks show up in Heroku logs